### PR TITLE
레시피 작성 후 상세보기 화면으로 이동 기능 추가 및 UI 레이아웃 개선

### DIFF
--- a/test/app/src/main/java/com/example/test/RecipeSeeActivity.kt
+++ b/test/app/src/main/java/com/example/test/RecipeSeeActivity.kt
@@ -197,7 +197,7 @@ class RecipeSeeActivity : AppCompatActivity() {
             stopTimer()
         }
         // 레시피 조회 기능 추가
-        val recipeId = 47L // 테스트용
+        val recipeId = intent.getLongExtra("RECIPE_ID", -1L)
         val token = App.prefs.token.toString()
 
         RetrofitInstance.apiService.getRecipeById("Bearer $token", recipeId)

--- a/test/app/src/main/java/com/example/test/RecipeWriteImageActivity.kt
+++ b/test/app/src/main/java/com/example/test/RecipeWriteImageActivity.kt
@@ -66,6 +66,7 @@ private lateinit var minuteEditText: EditText
 private lateinit var startTextView: TextView
 private lateinit var timeSeparator: TextView
 private lateinit var deleteTextView: TextView
+private var createdRecipeId: Long? = null
 private var itemCount = 0 // 추가된 개수 추적
 private val maxItems = 10 // 최대 10개 제한
 private val buttonMarginIncrease = 130 // 버튼을 아래로 내릴 거리 (px)
@@ -856,6 +857,7 @@ class RecipeWriteImageActivity : AppCompatActivity() {
                 RecipeRepository.uploadRecipe(token.toString(), recipe) { response ->
                     if (response != null) {
                         Toast.makeText(this, "레시피 업로드 성공!", Toast.LENGTH_SHORT).show()
+                        createdRecipeId = response.recipeId?.toLong()
                     } else {
                         Toast.makeText(this, "레시피 업로드 실패", Toast.LENGTH_SHORT).show()
 
@@ -977,23 +979,25 @@ class RecipeWriteImageActivity : AppCompatActivity() {
         }
 
         // 레시피 등록한 레시피 확인 (작은 등록하기 클릭시 화면 이동)
-        register.setOnClickListener {
-            registerRecipeUpLayout.visibility = View.VISIBLE
-            registerRecipeSeeLayout.visibility = View.VISIBLE
-            contentCheckTapBar.visibility = View.GONE
-            recipeRegister.visibility = View.GONE
-            contentCheckLayout.visibility = View.GONE
-            recipeWrite.visibility = View.GONE
+        registerFixButton.setOnClickListener {
+            if (createdRecipeId != null) {
+                val intent = Intent(this, RecipeSeeActivity::class.java)
+                intent.putExtra("RECIPE_ID", createdRecipeId!!)
+                startActivity(intent)
+            } else {
+                Toast.makeText(this, "레시피 ID를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
         }
 
         // 레시피 등록한 레시피 확인 (큰 등록하기 클릭시 화면 이동)
         registerFixButton.setOnClickListener {
-            registerRecipeUpLayout.visibility = View.VISIBLE
-            registerRecipeSeeLayout.visibility = View.VISIBLE
-            contentCheckTapBar.visibility = View.GONE
-            recipeRegister.visibility = View.GONE
-            contentCheckLayout.visibility = View.GONE
-            recipeWrite.visibility = View.GONE
+            if (createdRecipeId != null) {
+                val intent = Intent(this, RecipeSeeActivity::class.java)
+                intent.putExtra("RECIPE_ID", createdRecipeId!!)
+                startActivity(intent)
+            } else {
+                Toast.makeText(this, "레시피 ID를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+            }
         }
     }
     //재료, 대체 재료, 재료 처리 방법 추가

--- a/test/app/src/main/java/com/example/test/network/RetrofitInstance.kt
+++ b/test/app/src/main/java/com/example/test/network/RetrofitInstance.kt
@@ -6,7 +6,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 object RetrofitInstance {
-    const val BASE_URL = "http://172.16.100.182:8080"
+    const val BASE_URL = "http://192.168.68.111:8080"
 
     // 로깅 인터셉터 (필요에 따라 설정, 디버깅 용도)
     private val loggingInterceptor = HttpLoggingInterceptor().apply {

--- a/test/app/src/main/res/layout/activity_recipe_write_image.xml
+++ b/test/app/src/main/res/layout/activity_recipe_write_image.xml
@@ -3014,17 +3014,16 @@
                     <!-- 대표사진 -->
                     <ImageView
                         android:id="@+id/representativeImage"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
+                        android:layout_width="match_parent"
+                        android:layout_height="200dp"
+                        android:scaleType="centerCrop"
                         android:layout_marginTop="44dp"
+                        android:layout_marginStart="20dp"
                         android:layout_marginEnd="20dp"
                         android:background="?attr/selectableItemBackgroundBorderless"
-                        android:src="@drawable/image_recipe_write"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintHorizontal_bias="0.526"
+                        app:layout_constraintTop_toBottomOf="@id/representative"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/representative" />
+                        app:layout_constraintEnd_toEndOf="parent" />
 
                     <!-- 카테고리 -->
                     <TextView
@@ -3328,133 +3327,15 @@
                         android:background="@drawable/bar_rectangle"
                         app:layout_constraintTop_toBottomOf="@id/cookOrder" />
 
-                    <!-- STEP 1 -->
-                    <TextView
-                        android:id="@+id/contentCheckOne"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginTop="26dp"
-                        android:text="STEP 1"
-                        android:textColor="#000000"
-                        android:textSize="15sp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/divideRectangleBarThirtyfive" />
-
-                    <!-- 비엔나 소시지 이미지 -->
-                    <ImageView
-                        android:id="@+id/contentCheckImageOne"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/image_write_eight_one"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginEnd="20dp"
-                        android:layout_marginTop="15dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/contentCheckOne"/>
-
-                    <!-- 내용 1 -->
-                    <TextView
-                        android:id="@+id/content"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="0dp"
-                        android:layout_marginTop="26dp"
-                        android:text="비엔나소시지는 한쪽에만 칼집을 낸 후, 끓는 물에 넣어 30초 정도 데\n쳐주세요"
-                        android:textColor="#000000"
-                        android:textSize="13sp"
-                        app:layout_constraintStart_toStartOf="@id/contentCheckImageOne"
-                        app:layout_constraintTop_toBottomOf="@id/contentCheckImageOne" />
-
-                    <!-- 타이머 -->
-                    <TextView
-                        android:id="@+id/timerTwo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="0dp"
-                        android:layout_marginTop="20dp"
-                        android:text="타이머"
-                        android:textColor="#000000"
-                        android:textSize="15sp"
-                        app:layout_constraintStart_toStartOf="@id/contentCheckImageOne"
-                        app:layout_constraintTop_toBottomOf="@id/content" />
-
-                    <!-- 시간 -->
-                    <TextView
-                        android:id="@+id/timeTwo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="30dp"
-                        android:layout_marginTop="10dp"
-                        android:text="00:30"
-                        android:textColor="#2B2B2B"
-                        android:textSize="32sp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/content" />
-
-                    <!-- STEP 1 아래 바 -->
-                    <View
-                        android:id="@+id/divideRectangleBarThirtysix"
+                    <LinearLayout
+                        android:id="@+id/stepSeeContainer"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
                         android:layout_marginTop="20dp"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginEnd="20dp"
-                        android:background="@drawable/bar_rectangle"
-                        app:layout_constraintTop_toBottomOf="@id/timeTwo" />
-
-                    <!-- STEP 2 -->
-                    <TextView
-                        android:id="@+id/contentCheckStepTwo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginTop="26dp"
-                        android:text="STEP 2"
-                        android:textColor="#000000"
-                        android:textSize="15sp"
+                        app:layout_constraintTop_toBottomOf="@id/divideRectangleBarThirtyfive"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/divideRectangleBarThirtysix" />
-
-                    <!-- 비엔나 소시지 이미지 -->
-                    <ImageView
-                        android:id="@+id/contentCheckImageTwo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/image_write_eight_two"
-                        android:background="?attr/selectableItemBackgroundBorderless"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginEnd="20dp"
-                        android:layout_marginTop="15dp"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/contentCheckStepTwo"/>
-
-                    <!-- 내용 2 -->
-                    <TextView
-                        android:id="@+id/contentCheckTwo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginStart="0dp"
-                        android:layout_marginTop="26dp"
-                        android:text="양파와 파프리카는 한입크기로 크기로 썰고, 파슬리는 잘게 다져주세\n요."
-                        android:textColor="#000000"
-                        android:textSize="13sp"
-                        app:layout_constraintStart_toStartOf="@id/contentCheckImageTwo"
-                        app:layout_constraintTop_toBottomOf="@id/contentCheckImageTwo" />
-
-                    <!-- STEP 2 아래 바 -->
-                    <View
-                        android:id="@+id/divideRectangleBarThirtyseven"
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:layout_marginTop="15dp"
-                        android:layout_marginStart="20dp"
-                        android:layout_marginEnd="20dp"
-                        android:background="@drawable/bar_rectangle"
-                        app:layout_constraintTop_toBottomOf="@id/contentCheckTwo" />
+                        app:layout_constraintEnd_toEndOf="parent" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </ScrollView>

--- a/test/app/src/main/res/xml/network_security_config.xml
+++ b/test/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">172.16.100.182</domain>
+        <domain includeSubdomains="true">192.168.68.111</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
- 레시피 작성 후 확인 화면(contentCheckLayout) 구성 및 데이터 바인딩 구현

- endFixButton 클릭 시:
  - 입력한 제목, 카테고리, 재료, 대체재료, 처리방법, 조리순서, 대표 이미지 등 UI에 출력
  - 서버로 레시피 업로드 요청 (RecipeRequest)

- 업로드 성공 시 응답값에서 recipeId 추출하여 저장

- 작성 완료 (registerFixButton) 버튼 클릭 시:
  - 바로 RecipeSeeActivity로 이동하도록 구현 (Intent 사용)
  - recipeId를 넘겨 서버에서 해당 레시피 상세 조회

- 조리순서 레이아웃 ID stepContainer → stepSeeContainer로 수정하여 기존 레이아웃과 충돌 방지